### PR TITLE
Add configurable base_url support for local models

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,10 @@ pub struct ConfigLayer {
     /// Print API messages before sending them.
     #[arg(long)]
     pub print_messages: Option<bool>,
+
+    /// The base URL for the API client.
+    #[arg(long)]
+    pub base_url: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -76,6 +80,7 @@ pub struct Config {
     pub show_system_prompt: bool,
     pub show_tool_call_args: bool,
     pub print_messages: bool,
+    pub base_url: String,
 }
 
 impl Config {
@@ -123,6 +128,9 @@ impl Config {
         if let Some(print_messages) = layer.print_messages {
             self.print_messages = print_messages;
         }
+        if let Some(base_url) = &layer.base_url {
+            self.base_url = base_url.clone();
+        }
     }
 }
 
@@ -146,6 +154,7 @@ impl Default for Config {
             show_system_prompt: false,
             show_tool_call_args: false,
             print_messages: false,
+            base_url: "https://openrouter.ai/api/v1/".to_string(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 
     let api_key = utils::load_api_key_from_env().expect("OPENROUTER_API_KEY not set");
     let or_client = OpenRouterClient::new()
-        .with_base_url("https://openrouter.ai/api/v1/")?
+        .with_base_url(&config.base_url)?
         .with_timeout(Duration::from_secs(config.timeout_seconds))
         .with_api_key(api_key)?;
 


### PR DESCRIPTION
Add configurable base_url support for local models like Ollama

## Summary
- Add configurable base_url support for local models like Ollama
- Add --base-url CLI argument for specifying API endpoint
- Maintain backwards compatibility with OpenRouter as default
- Enable support for local model servers and custom endpoints

## Changes
- Added base_url field to ConfigLayer and Config structs
- Added CLI argument --base-url for specifying API endpoint
- Updated client creation to use config.base_url instead of hardcoded URL
- Set OpenRouter URL as default to maintain backwards compatibility
- Added merge logic for base_url configuration

## Usage Examples
```bash
# Use with Ollama local server
./ass --base-url "http://localhost:11434/v1/" "Hello world"

# Config file (config.toml)
base_url = "http://localhost:11434/v1/"
```

Resolves #1

Generated with [Claude Code](https://claude.ai/code)